### PR TITLE
Refactor rules and parsing utilities

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,12 +1,6 @@
 import { Coordinate, Move } from "./types";
+import { coordFromString } from "./utils";
 
-function parseCoord(input: string): Coordinate | null {
-  const match = /^([A-K])(10|11|[1-9])$/.exec(input.trim().toUpperCase());
-  if (!match) return null;
-  const file = match[1].charCodeAt(0) - 65;
-  const rank = 11 - parseInt(match[2], 10);
-  return { x: file, y: rank };
-}
 
 export function parseMove(input: string): Move | null {
   const pattern = /^([A-K](?:10|11|[1-9]))-([A-K](?:10|11|[1-9]))(?:\(([^)]+)\))?$/i;
@@ -14,8 +8,8 @@ export function parseMove(input: string): Move | null {
   const match = pattern.exec(cleaned);
   if (!match) return null;
 
-  const from = parseCoord(match[1]);
-  const to = parseCoord(match[2]);
+  const from = coordFromString(match[1]);
+  const to = coordFromString(match[2]);
   if (!from || !to) return null;
 
   const captures = [];
@@ -25,7 +19,7 @@ export function parseMove(input: string): Move | null {
     const capturePattern = /[A-K](?:10|11|[1-9])/g;
     let captureMatch;
     while ((captureMatch = capturePattern.exec(captureChunk)) !== null) {
-      const cap = parseCoord(captureMatch[0]);
+      const cap = coordFromString(captureMatch[0]);
       if (cap) captures.push(cap);
     }
   }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -16,6 +16,8 @@ export function getAvailableCaptures(
     { dx: 1, dy: 0 }
   ];
 
+  const size = board.length;
+
   function kingWouldBeCaptured(x: number, y: number): boolean {
     if (player !== "attacker") return false;
 
@@ -30,7 +32,7 @@ export function getAvailableCaptures(
     for (const { dx, dy } of checks) {
       const nx = x + dx;
       const ny = y + dy;
-      if (nx < 0 || ny < 0 || nx >= 11 || ny >= 11) return false;
+      if (nx < 0 || ny < 0 || nx >= size || ny >= size) return false;
 
       const cell = board[ny][nx];
       let occ = cell.occupant;
@@ -53,8 +55,8 @@ export function getAvailableCaptures(
     const beyondY = move.to.y + dy * 2;
 
     if (
-      midX < 0 || midX >= 11 || midY < 0 || midY >= 11 ||
-      beyondX < 0 || beyondX >= 11 || beyondY < 0 || beyondY >= 11
+      midX < 0 || midX >= size || midY < 0 || midY >= size ||
+      beyondX < 0 || beyondX >= size || beyondY < 0 || beyondY >= size
     ) continue;
 
     const middle = board[midY][midX];
@@ -77,8 +79,9 @@ export function getAvailableCaptures(
 }
 
 export function isKingCaptured(board: CellState[][]): boolean {
-  for (let y = 0; y < board.length; y++) {
-    for (let x = 0; x < board.length; x++) {
+  const size = board.length;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
       if (board[y][x].occupant === "king") {
         // Look around for attackers or capture squares
         const adj = [
@@ -91,7 +94,7 @@ export function isKingCaptured(board: CellState[][]): boolean {
         let surrounded = 0;
         for (const { x: nx, y: ny } of adj) {
           if (
-            nx >= 0 && ny >= 0 && nx < 11 && ny < 11 &&
+            nx >= 0 && ny >= 0 && nx < size && ny < size &&
             (board[ny][nx].occupant === "attacker" ||
               board[ny][nx].isThrone ||
               board[ny][nx].isCorner)
@@ -108,9 +111,9 @@ export function isKingCaptured(board: CellState[][]): boolean {
   return false;
 }
 
-export function isKingEscaped(coord: Coordinate): boolean {
+export function isKingEscaped(coord: Coordinate, boardSize = 11): boolean {
   return (
-    (coord.x === 0 || coord.x === 10) &&
-    (coord.y === 0 || coord.y === 10)
+    (coord.x === 0 || coord.x === boardSize - 1) &&
+    (coord.y === 0 || coord.y === boardSize - 1)
   );
 }


### PR DESCRIPTION
## Summary
- centralize capture detection in `rules` module
- reuse `coordFromString` in parser
- make rule helpers use board size dynamically

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c1c19a7388328b8baf259cae86874