### PR TITLE
Fix parsing of 2-digit ranks and centralize regex

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -133,7 +133,7 @@
 
     <script type="module">
         import { HnefataflEngine } from '../src/HnefataflEngine.js';
-        import { parseMoveSequence } from '../src/parser.js';
+        import { parseMove, parseMoveSequence } from '../src/parser.js';
 
         const boardEl = document.getElementById('board');
         const fromInput = document.getElementById('fromInput');
@@ -217,20 +217,9 @@
             gameStatusEl.textContent = state.status;
 
             const parsedMoves = state.moveHistory.map((str) => {
-                if (str === 'P')
-                    return 'pass';
-                const match = /^([A-K][1-9]|10|11)-([A-K][1-9]|10|11)(?:\(([A-K0-9]+)\))?$/i.exec(str.replace(/\s+/g, ""));
-                if (!match) 
-                    return 'pass'; // fallback
-                const parse = str => {
-                    const file = str.charCodeAt(0) - 65;
-                    const rank = 11 - parseInt(str.slice(1));
-                    return { x: file, y: rank };
-                };
-                const from = parse(match[1]);
-                const to = parse(match[2]);
-                const captures = match[3] ? match[3].match(/.{1,2}/g).map(parse) : [];
-                return { from, to, captures };
+                if (str === 'P') return 'pass';
+                const move = parseMove(str);
+                return move ? move : 'pass';
             });
 
             renderMoveList(currentMovesList, parsedMoves);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,11 +1,11 @@
 import { Coordinate, Move } from "./types";
 import { coordFromString } from "./utils";
+import { MOVE_RE, CAPTURE_RE } from "./patterns";
 
 
 export function parseMove(input: string): Move | null {
-  const pattern = /^([A-K](?:10|11|[1-9]))-([A-K](?:10|11|[1-9]))(?:\(([^)]+)\))?$/i;
   const cleaned = input.trim().replace(/\s+/g, "");
-  const match = pattern.exec(cleaned);
+  const match = MOVE_RE.exec(cleaned);
   if (!match) return null;
 
   const from = coordFromString(match[1]);
@@ -16,9 +16,8 @@ export function parseMove(input: string): Move | null {
   const captureChunk = match[3];
   if (captureChunk) {
     // Parse captures by matching coordinate patterns
-    const capturePattern = /[A-K](?:10|11|[1-9])/g;
     let captureMatch;
-    while ((captureMatch = capturePattern.exec(captureChunk)) !== null) {
+    while ((captureMatch = CAPTURE_RE.exec(captureChunk)) !== null) {
       const cap = coordFromString(captureMatch[0]);
       if (cap) captures.push(cap);
     }

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,0 +1,4 @@
+export const COORD_BODY = "[A-K](?:10|11|[1-9])";
+export const COORD_CAPTURE_RE = /^([A-K])(10|11|[1-9])$/i;
+export const MOVE_RE = new RegExp(`^(${COORD_BODY})-(${COORD_BODY})(?:\\(([^)]+)\\))?$`, 'i');
+export const CAPTURE_RE = new RegExp(COORD_BODY, 'g');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
 import { Coordinate, CellState } from "./types";
+import { COORD_CAPTURE_RE } from "./patterns";
 
 export function coordFromString(input: string): Coordinate | null {
-  const match = /^([A-K])([1-9]|10|11)$/.exec(input.trim().toUpperCase());
+  const match = COORD_CAPTURE_RE.exec(input.trim().toUpperCase());
   if (!match) return null;
   const file = match[1].charCodeAt(0) - 65;
   const rank = 11 - parseInt(match[2], 10);


### PR DESCRIPTION
## Summary
- centralize regex patterns in `patterns.ts`
- use shared patterns in `utils.ts` and `parser.ts`
- replace fragile regex in debug UI with `parseMove`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c240442f88328af415e5afb8bf2ee