### PR TITLE
feat: centralize piece movement

### DIFF
--- a/src/HnefataflEngine.ts
+++ b/src/HnefataflEngine.ts
@@ -1,7 +1,6 @@
-import { createInitialBoard, STANDARD_BOARD, extractDefenderPosition } from "./board"
+import { createInitialBoard, STANDARD_BOARD, extractDefenderPosition, movePiece } from "./board"
 import { validateMove as validateRawMove } from "./validator"
 import { parseMove } from "./parser"
-import { cloneBoard } from "./board"
 import { coordToString } from "./utils"
 import { getAvailableCaptures } from "./rules"
 import { isKingCaptured, isKingEscaped } from "./rules"
@@ -57,10 +56,8 @@ export class HnefataflEngine {
         if (!validation.isValid) 
             return { success: false, error: validation.reason }
 
-        const board = cloneBoard(this.state.board)
-        const piece = board[move.from.y][move.from.x].occupant
-        board[move.from.y][move.from.x].occupant = null
-        board[move.to.y][move.to.x].occupant = piece
+        const board = movePiece(this.state.board, move)
+        const piece = board[move.to.y][move.to.x].occupant
 
         const actualCaptures = getAvailableCaptures(board, move, this.state.currentPlayer)
         for (const cap of move.captures) {

--- a/src/board.ts
+++ b/src/board.ts
@@ -6,6 +6,14 @@ export function cloneBoard(board: CellState[][]): CellState[][] {
   );
 }
 
+export function movePiece(board: CellState[][], move: Move): CellState[][] {
+  const newBoard = cloneBoard(board);
+  const piece = newBoard[move.from.y][move.from.x].occupant;
+  newBoard[move.from.y][move.from.x].occupant = null;
+  newBoard[move.to.y][move.to.x].occupant = piece;
+  return newBoard;
+}
+
 export function extractDefenderPosition(board: CellState[][], move?: Move): string[] {
   return board.map((row, y) =>
     row

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,7 +1,7 @@
 import { CellState, Coordinate, Move, MoveValidationResult, Player } from "./types";
 import { coordToString } from "./utils";
 import { getAvailableCaptures } from "./rules";
-import { cloneBoard, extractDefenderPosition } from "./board";
+import { extractDefenderPosition, movePiece } from "./board";
 
 function isSameCoord(a: Coordinate, b: Coordinate): boolean {
   return a.x === b.x && a.y === b.y;
@@ -69,10 +69,7 @@ export function validateMove(
   }
 
   if (player === "defender") {
-    const simulated = cloneBoard(board);
-    const piece = simulated[move.from.y][move.from.x].occupant;
-    simulated[move.from.y][move.from.x].occupant = null;
-    simulated[move.to.y][move.to.x].occupant = piece;
+    const simulated = movePiece(board, move);
     const pos = extractDefenderPosition(simulated);
     const repeat = defenderPositions.some(p => p.length === pos.length && p.every((r, i) => r === pos[i]));
     if (repeat) {


### PR DESCRIPTION
## Summary
- add `movePiece` helper to clone and move pieces on the board
- refactor engine applyMove and validator defender repeat to use helper

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689e89727ab8832891763edb58d50ad4