### PR TITLE
Use board projection for defender repeat detection

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,7 +1,7 @@
 import { CellState, Coordinate, Move, MoveValidationResult, Player } from "./types";
 import { coordToString } from "./utils";
 import { getAvailableCaptures } from "./rules";
-import { cloneBoard, extractDefenderPosition } from "./board";
+import { extractDefenderPosition } from "./board";
 
 function isSameCoord(a: Coordinate, b: Coordinate): boolean {
   return a.x === b.x && a.y === b.y;
@@ -69,12 +69,10 @@ export function validateMove(
   }
 
   if (player === "defender") {
-    const simulated = cloneBoard(board);
-    const piece = simulated[move.from.y][move.from.x].occupant;
-    simulated[move.from.y][move.from.x].occupant = null;
-    simulated[move.to.y][move.to.x].occupant = piece;
-    const pos = extractDefenderPosition(simulated);
-    const repeat = defenderPositions.some(p => p.length === pos.length && p.every((r, i) => r === pos[i]));
+    const pos = extractDefenderPosition(board, move);
+    const repeat = defenderPositions.some(
+      p => p.length === pos.length && p.every((r, i) => r === pos[i])
+    );
     if (repeat) {
       return {
         isValid: false,


### PR DESCRIPTION
## Summary
- simplify defender repeat check by using `extractDefenderPosition(board, move)`
- remove manual board cloning and piece movement

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689e8bf0faa88328a9f440f105ef1e22