### PR TITLE
Add tests for missing Hnefatafl rules

### DIFF
--- a/src/engine.test.ts
+++ b/src/engine.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest'
+import { HnefataflEngine } from './HnefataflEngine'
+import { Player, Piece } from './types'
+
+describe('Engine initial state', () => {
+    test('Attacker moves first', () => {
+        const engine = new HnefataflEngine()
+        const state = engine.getState()
+        expect(state.currentPlayer).toBe(Player.Attacker)
+    })
+
+    test('King starts on throne which is restricted', () => {
+        const engine = new HnefataflEngine()
+        const board = engine.getState().board
+        const size = board.length
+        const center = Math.floor(size / 2)
+        const throne = board[center][center]
+        expect(throne.occupant).toBe(Piece.King)
+        expect(throne.isThrone).toBe(true)
+        expect(throne.isRestricted).toBe(true)
+    })
+})

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -164,4 +164,60 @@ describe('Validator Tests', () => {
         expect(result2.reason).toContain('repeat')
     })
 
+    test('Diagonal move is invalid', () => {
+        const boardLayout = [
+            "R K  ",
+            "     ",
+            "  A  ",
+            "     ",
+            "R   R"
+        ]
+        const board = createInitialBoard(boardLayout)
+        const move = {
+            from: { x: 2, y: 2 },
+            to: { x: 3, y: 3 },
+            captures: []
+        }
+        const result = validateMove(board, Player.Attacker, move)
+        expect(result.isValid).toBe(false)
+    })
+
+    test('Throne occupied by king is not hostile to defenders', () => {
+        const boardLayout = [
+            "R   R",
+            "A    ",
+            " DK  ",
+            "     ",
+            "R   R"
+        ]
+        const board = createInitialBoard(boardLayout)
+        const move = {
+            from: { x: 0, y: 1 },
+            to: { x: 0, y: 2 },
+            captures: [{ x: 1, y: 2 }]
+        }
+        const result = validateMove(board, Player.Attacker, move)
+        expect(result.isValid).toBe(false)
+        expect(result.expectedCaptures).toEqual([])
+    })
+
+    test('Edge enclosure captures defenders', () => {
+        const boardLayout = [
+            "R   R",
+            "A    ",
+            "D K  ",
+            "A    ",
+            "RA  R"
+        ]
+        const board = createInitialBoard(boardLayout)
+        const move = {
+            from: { x: 1, y: 4 },
+            to: { x: 1, y: 2 },
+            captures: [{ x: 0, y: 2 }]
+        }
+        const result = validateMove(board, Player.Attacker, move)
+        expect(result.isValid).toBe(true)
+        expect(result.expectedCaptures).toContainEqual({ x: 0, y: 2 })
+    })
+
 })


### PR DESCRIPTION
## Summary
- add engine tests for attacker starting player and initial throne placement
- add validator tests covering diagonal moves, throne hostility, and edge captures

## Testing
- `npm test` *(fails: Engine initial state > Attacker moves first, Validator Tests > Throne occupied by king is not hostile to defenders, Validator Tests > Edge enclosure captures defenders)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fd7b74d083289c60f158bd9f405a